### PR TITLE
feat: add allowEphemeral config to disable ephemeral minions

### DIFF
--- a/src/commands/minions.ts
+++ b/src/commands/minions.ts
@@ -28,6 +28,7 @@ function reverseChangelog(content: string): string {
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
 import { discoverAgents } from "../agents.js";
+import { getConfig } from "../config.js";
 import { logger } from "../logger.js";
 import type { ResultQueue } from "../queue.js";
 import type { EventBus } from "../subsessions/event-bus.js";
@@ -163,8 +164,11 @@ async function showMinionWithCycling(
 
 export function showListMinions(ctx: ExtensionCommandContext) {
   const { agents } = discoverAgents(ctx.cwd, "both");
+  const config = getConfig(ctx);
   const lines = ["Available minion types:"];
-  lines.push("  minion (built-in): General-purpose ephemeral minion with default capabilities");
+  if (config.allowEphemeral) {
+    lines.push("  minion (built-in): General-purpose ephemeral minion with default capabilities");
+  }
 
   for (const a of agents) {
     const model = a.model ? ` [model: ${a.model}]` : "";

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,8 @@ import { getAgentDir } from "@mariozechner/pi-coding-agent";
 export interface PiMinionsConfig {
   /** Custom minion names (defaults to built-in pool) */
   minionNames?: string[];
+  /** Allow spawning ephemeral (unnamed) minions (default: true) */
+  allowEphemeral?: boolean;
   /** Delegation behavior settings */
   delegation?: DelegationConfig;
   /** Display/rendering settings */
@@ -51,6 +53,7 @@ export interface DisplayConfig {
 /** Fully resolved config with all defaults applied */
 export interface ResolvedConfig {
   minionNames: string[];
+  allowEphemeral: boolean;
   delegation: Required<DelegationConfig>;
   display: Required<DisplayConfig>;
   toolSync: Required<ToolSyncConfig>;
@@ -204,6 +207,7 @@ export function getConfig(ctx: ExtensionContext): ResolvedConfig {
   const user = settings["pi-minions"] ?? {};
   return {
     minionNames: [...(user.minionNames ?? DEFAULT_MINION_NAMES)],
+    allowEphemeral: user.allowEphemeral ?? true,
     delegation: {
       enabled: user.delegation?.enabled ?? true,
       toolCallThreshold: user.delegation?.toolCallThreshold ?? 16,

--- a/src/tools/list-agents.ts
+++ b/src/tools/list-agents.ts
@@ -1,6 +1,7 @@
 import type { AgentToolResult, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { discoverAgents } from "../agents.js";
+import { getConfig } from "../config.js";
 
 export const ListAgentsParams = Type.Object(
   {},
@@ -26,32 +27,33 @@ export function listAgents() {
     ctx: ExtensionContext,
   ): Promise<AgentToolResult<AgentInfo[]>> {
     const { agents } = discoverAgents(ctx.cwd, "both");
+    const piConfig = getConfig(ctx);
 
     const lines: string[] = [];
+    const details: AgentInfo[] = [];
 
-    // Built-in ephemeral minion (always available)
-    lines.push(
-      "- minion (built-in): General-purpose ephemeral minion with default capabilities. Used when no agent name is specified.",
-    );
+    // Built-in ephemeral minion (only when allowed)
+    if (piConfig.allowEphemeral) {
+      lines.push(
+        "- minion (built-in): General-purpose ephemeral minion with default capabilities. Used when no agent name is specified.",
+      );
+      details.push({
+        name: "minion",
+        description: "General-purpose ephemeral minion",
+        source: "built-in",
+      });
+    }
 
     for (const a of agents) {
       const model = a.model ? ` [model: ${a.model}]` : "";
       lines.push(`- ${a.name} (${a.source}): ${a.description}${model}`);
-    }
-
-    const details: AgentInfo[] = [
-      {
-        name: "minion",
-        description: "General-purpose ephemeral minion",
-        source: "built-in",
-      },
-      ...agents.map((a) => ({
+      details.push({
         name: a.name,
         description: a.description,
         source: a.source,
         model: a.model,
-      })),
-    ];
+      });
+    }
 
     return {
       content: [{ type: "text", text: `Available agents:\n${lines.join("\n")}` }],

--- a/src/tools/spawn.ts
+++ b/src/tools/spawn.ts
@@ -151,6 +151,18 @@ async function executeSpawn(
   const spinnerFrames = piConfig.display.spinnerFrames;
   const outputPreviewLines = piConfig.display.outputPreviewLines;
 
+  // Enforce ephemeral restriction
+  if (!piConfig.allowEphemeral) {
+    const ephemeralSpecs = specs.filter((s) => !s.agent);
+    if (ephemeralSpecs.length > 0) {
+      const { agents } = discoverAgents(ctx.cwd, "both");
+      const available = agents.map((a) => `- ${a.name}: ${a.description}`).join("\n");
+      throw new Error(
+        `Ephemeral minions are disabled. You must specify a named agent.\n\nAvailable agents:\n${available || "(none found)"}`,
+      );
+    }
+  }
+
   logger.info("spawn:tool", isSingleMinion ? "start" : "batch-start", {
     count: specs.length,
   });
@@ -603,6 +615,15 @@ export function spawnBg(
 
     const resolvedModel = params.model ?? config.model ?? ctx.model?.id;
     const piConfig = getConfig(ctx);
+
+    // Enforce ephemeral restriction
+    if (!piConfig.allowEphemeral && !params.agent) {
+      const { agents } = discoverAgents(ctx.cwd, "both");
+      const available = agents.map((a) => `- ${a.name}: ${a.description}`).join("\n");
+      throw new Error(
+        `Ephemeral minions are disabled. You must specify a named agent.\n\nAvailable agents:\n${available || "(none found)"}`,
+      );
+    }
 
     logger.info("spawn:tool", "start-bg", {
       id,

--- a/test/commands/minions.test.ts
+++ b/test/commands/minions.test.ts
@@ -28,9 +28,13 @@ vi.mock("../../src/version.js", () => ({
 }));
 
 // Mock fs module
-vi.mock("node:fs", () => ({
-  readFileSync: vi.fn().mockReturnValue("# Mock Changelog"),
-}));
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: vi.fn().mockReturnValue("# Mock Changelog"),
+  };
+});
 
 function createMockEventBus(): EventBus {
   return new EventBus();
@@ -80,6 +84,7 @@ function mockSession() {
 
 function createMockContext(overrides?: Partial<ExtensionCommandContext>): ExtensionCommandContext {
   return {
+    cwd: "/tmp",
     ui: {
       notify: vi.fn(),
     },

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -51,6 +51,7 @@ describe("getConfig", () => {
       const config = getConfig(ctx);
 
       expect(config.minionNames).toEqual(DEFAULT_MINION_NAMES);
+      expect(config.allowEphemeral).toBe(true);
       expect(config.delegation.enabled).toBe(true);
       expect(config.delegation.toolCallThreshold).toBe(16);
       expect(config.delegation.hintIntervalMinutes).toBe(8);
@@ -87,6 +88,20 @@ describe("getConfig", () => {
       const config = getConfig(ctx);
 
       expect(config.minionNames).toEqual(["alpha", "beta", "gamma"]);
+    });
+
+    it("reads allowEphemeral from global settings", () => {
+      const globalSettings = {
+        "pi-minions": {
+          allowEphemeral: false,
+        },
+      };
+      writeFileSync(join(agentDir, "settings.json"), JSON.stringify(globalSettings));
+
+      const ctx = createMockContext(tempDir);
+      const config = getConfig(ctx);
+
+      expect(config.allowEphemeral).toBe(false);
     });
 
     it("reads delegation settings from global settings", () => {
@@ -379,6 +394,7 @@ describe("Config types", () => {
   it("ResolvedConfig has all required fields", () => {
     const mockResolved: ResolvedConfig = {
       minionNames: ["test"],
+      allowEphemeral: true,
       delegation: {
         enabled: true,
         toolCallThreshold: 5,

--- a/test/tools/list-agents.test.ts
+++ b/test/tools/list-agents.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/agents.js", () => ({
+  discoverAgents: vi.fn(),
+}));
+vi.mock("../../src/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/config.js")>();
+  return {
+    ...actual,
+    getConfig: vi.fn(actual.getConfig),
+  };
+});
+
+import { discoverAgents } from "../../src/agents.js";
+import { getConfig } from "../../src/config.js";
+import { listAgents } from "../../src/tools/list-agents.js";
+
+const mockAgent = {
+  name: "scout",
+  description: "Fast recon",
+  systemPrompt: "You are a scout.",
+  source: "user" as const,
+  filePath: "/tmp/scout.md",
+};
+
+function createCtx() {
+  return {
+    cwd: "/tmp",
+    modelRegistry: {},
+    model: undefined,
+    ui: {},
+  } as any;
+}
+
+function defaultConfig() {
+  return {
+    minionNames: ["test"],
+    allowEphemeral: true,
+    delegation: { enabled: true, toolCallThreshold: 16, hintIntervalMinutes: 8 },
+    display: {
+      outputPreviewLines: 20,
+      observabilityLines: 6,
+      showStatusHints: true,
+      spinnerFrames: ["[oo]"],
+    },
+    toolSync: { enabled: true, maxWait: 5 },
+    interaction: { timeout: 300 },
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(discoverAgents).mockReturnValue({
+    agents: [mockAgent],
+    projectAgentsDir: null,
+  });
+  vi.mocked(getConfig).mockReturnValue(defaultConfig());
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("list-agents", () => {
+  it("includes ephemeral minion when allowEphemeral is true", async () => {
+    const execute = listAgents();
+    const result = await execute("tc", {} as never, undefined, undefined, createCtx());
+
+    expect(result.content[0]).toHaveProperty("text");
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("minion (built-in)");
+    expect(text).toContain("scout");
+
+    expect(result.details).toHaveLength(2);
+    expect(result.details![0].name).toBe("minion");
+    expect(result.details![1].name).toBe("scout");
+  });
+
+  it("hides ephemeral minion when allowEphemeral is false", async () => {
+    vi.mocked(getConfig).mockReturnValue({ ...defaultConfig(), allowEphemeral: false });
+
+    const execute = listAgents();
+    const result = await execute("tc", {} as never, undefined, undefined, createCtx());
+
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).not.toContain("minion (built-in)");
+    expect(text).toContain("scout");
+
+    expect(result.details).toHaveLength(1);
+    expect(result.details![0].name).toBe("scout");
+  });
+
+  it("shows only named agents when ephemeral is disabled and multiple agents exist", async () => {
+    const anotherAgent = {
+      ...mockAgent,
+      name: "builder",
+      description: "Builds things",
+    };
+    vi.mocked(discoverAgents).mockReturnValue({
+      agents: [mockAgent, anotherAgent],
+      projectAgentsDir: null,
+    });
+    vi.mocked(getConfig).mockReturnValue({ ...defaultConfig(), allowEphemeral: false });
+
+    const execute = listAgents();
+    const result = await execute("tc", {} as never, undefined, undefined, createCtx());
+
+    expect(result.details).toHaveLength(2);
+    expect(result.details!.map((d) => d.name)).toEqual(["scout", "builder"]);
+  });
+});

--- a/test/tools/spawn.test.ts
+++ b/test/tools/spawn.test.ts
@@ -18,8 +18,16 @@ vi.mock("../../src/agents.js", () => ({
 vi.mock("../../src/spawn.js", () => ({
   runMinionSession: vi.fn(),
 }));
+vi.mock("../../src/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/config.js")>();
+  return {
+    ...actual,
+    getConfig: vi.fn(actual.getConfig),
+  };
+});
 
 import { discoverAgents } from "../../src/agents.js";
+import { getConfig } from "../../src/config.js";
 import { runMinionSession } from "../../src/spawn.js";
 import { detachMinion, spawn, spawnBg } from "../../src/tools/spawn.js";
 import { emptyUsage } from "../../src/types.js";
@@ -1420,5 +1428,109 @@ describe("spawnBg — foreground attachment", () => {
 
     // sendMessage was already called during completion
     expect(pi.sendMessage).toHaveBeenCalled();
+  });
+});
+
+describe("ephemeral restriction (allowEphemeral: false)", () => {
+  function configWithEphemeralDisabled() {
+    vi.mocked(getConfig).mockReturnValue({
+      minionNames: ["test"],
+      allowEphemeral: false,
+      delegation: { enabled: true, toolCallThreshold: 16, hintIntervalMinutes: 8 },
+      display: {
+        outputPreviewLines: 20,
+        observabilityLines: 6,
+        showStatusHints: true,
+        spinnerFrames: ["[oo]"],
+      },
+      toolSync: { enabled: true, maxWait: 5 },
+      interaction: { timeout: 300 },
+    });
+  }
+
+  afterEach(() => {
+    vi.mocked(getConfig).mockRestore();
+  });
+
+  it("spawn rejects ephemeral minion when disabled", async () => {
+    configWithEphemeralDisabled();
+    const { tree, queue, pi, subsessionManager } = createDeps();
+    const execute = spawn(tree, queue, pi, subsessionManager);
+
+    await expect(
+      execute("tc", { task: "do something" }, undefined, undefined, createCtx()),
+    ).rejects.toThrow("Ephemeral minions are disabled");
+  });
+
+  it("spawn allows named agent when ephemeral is disabled", async () => {
+    configWithEphemeralDisabled();
+    const { tree, queue, pi, subsessionManager } = createDeps();
+    const execute = spawn(tree, queue, pi, subsessionManager);
+
+    const result = await execute(
+      "tc",
+      { task: "do something", agent: "scout" },
+      undefined,
+      undefined,
+      createCtx(),
+    );
+
+    expect(result.content[0]).toHaveProperty("text");
+    expect(tree.getRoots()).toHaveLength(1);
+  });
+
+  it("spawn_bg rejects ephemeral minion when disabled", async () => {
+    configWithEphemeralDisabled();
+    const { tree, queue, pi, subsessionManager } = createDeps();
+    const execute = spawnBg(tree, queue, pi, subsessionManager);
+
+    await expect(
+      execute("tc", { task: "bg task" }, undefined, undefined, createCtx()),
+    ).rejects.toThrow("Ephemeral minions are disabled");
+  });
+
+  it("spawn_bg allows named agent when ephemeral is disabled", async () => {
+    configWithEphemeralDisabled();
+    const { tree, queue, pi, subsessionManager } = createDeps();
+    const execute = spawnBg(tree, queue, pi, subsessionManager);
+
+    const result = await execute(
+      "tc",
+      { task: "bg task", agent: "scout" },
+      undefined,
+      undefined,
+      createCtx(),
+    );
+
+    expect(result.content[0]).toHaveProperty("text");
+    expect(tree.getRoots()).toHaveLength(1);
+  });
+
+  it("batch spawn rejects when any spec lacks an agent", async () => {
+    configWithEphemeralDisabled();
+    const { tree, queue, pi, subsessionManager } = createDeps();
+    const execute = spawn(tree, queue, pi, subsessionManager);
+
+    await expect(
+      execute(
+        "tc",
+        {
+          tasks: [{ task: "task1", agent: "scout" }, { task: "task2" }],
+        },
+        undefined,
+        undefined,
+        createCtx(),
+      ),
+    ).rejects.toThrow("Ephemeral minions are disabled");
+  });
+
+  it("error message includes available agent names", async () => {
+    configWithEphemeralDisabled();
+    const { tree, queue, pi, subsessionManager } = createDeps();
+    const execute = spawn(tree, queue, pi, subsessionManager);
+
+    await expect(
+      execute("tc", { task: "do something" }, undefined, undefined, createCtx()),
+    ).rejects.toThrow("scout");
   });
 });


### PR DESCRIPTION
## Summary

Adds `allowEphemeral` setting (default: true) to control whether ephemeral minions can be spawned. When set to false, the LLM is forced to pick a named agent.

## References

- Closes #7

## Decisions & callouts

- **Defaults to `true`** — existing behavior is preserved. Users opt in by setting `"allowEphemeral": false` in their `pi-minions` settings.
- **Error on spawn** — when disabled, `spawn`/`spawn_bg` throw with the list of available agents so the LLM can self-correct. Consistent with other validation errors like unknown agent names.
- **Hidden from listings** — the built-in ephemeral entry is removed from `list_agents` and `/minions list` when disabled.

## Manual testing

- [x] Set `"allowEphemeral": false` in `~/.pi/agent/settings.json` under `"pi-minions"`, confirm `spawn` without an agent returns an error listing available agents
- [x] Run `/minions list` with ephemeral disabled — the built-in ephemeral entry should be hidden