### PR TITLE
fix: wire up AgentConfig.tools to filter minion tool access

### DIFF
--- a/src/subsessions/manager.ts
+++ b/src/subsessions/manager.ts
@@ -124,6 +124,11 @@ export class SubsessionManager {
       await this.waitForAsyncTools(id, session, options.parentToolNames, options.toolSyncMaxWait);
     }
 
+    // Filter active tools if the agent config specifies a tool allowlist
+    if (config.tools && config.tools.length > 0) {
+      session.setActiveToolsByName(config.tools);
+    }
+
     // Store the session for steer/halt operations
     this.activeSessions.set(id, session);
 

--- a/test/subsessions/manager.test.ts
+++ b/test/subsessions/manager.test.ts
@@ -31,6 +31,7 @@ vi.mock("@mariozechner/pi-coding-agent", () => {
       { name: "edit", description: "Edit files" },
     ]),
     bindExtensions: vi.fn().mockResolvedValue(undefined),
+    setActiveToolsByName: vi.fn(),
   };
 
   const mockSessionManager = {
@@ -1032,6 +1033,65 @@ describe("SubsessionManager", () => {
       // Should return instantly — getAllTools never called for polling
       expect(Date.now() - start).toBeLessThan(1000);
       expect(getAllToolsMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("tool filtering via AgentConfig.tools", () => {
+    it("calls setActiveToolsByName when config.tools is set", async () => {
+      const manager = new SubsessionManager(tempDir, join(tempDir, "parent.jsonl"));
+      const { createAgentSession } = await import("@mariozechner/pi-coding-agent");
+      const mockSession = (await (createAgentSession as any)()).session;
+      mockSession.setActiveToolsByName.mockClear();
+
+      await manager.create({
+        id: "tool-filter-1",
+        name: "filtered",
+        task: "test",
+        config: {
+          name: "scout",
+          description: "Recon agent",
+          systemPrompt: "You are a scout.",
+          source: "user",
+          filePath: "/tmp/scout.md",
+          tools: ["read", "bash"],
+        },
+        spawnedBy: "test",
+        cwd: tempDir,
+        modelRegistry: {} as any,
+        parentModel: undefined as any,
+        toolSyncEnabled: false,
+        onComplete: vi.fn(),
+      });
+
+      expect(mockSession.setActiveToolsByName).toHaveBeenCalledWith(["read", "bash"]);
+    });
+
+    it("does not call setActiveToolsByName when config.tools is undefined", async () => {
+      const manager = new SubsessionManager(tempDir, join(tempDir, "parent.jsonl"));
+      const { createAgentSession } = await import("@mariozechner/pi-coding-agent");
+      const mockSession = (await (createAgentSession as any)()).session;
+      mockSession.setActiveToolsByName.mockClear();
+
+      await manager.create({
+        id: "tool-filter-2",
+        name: "unfiltered",
+        task: "test",
+        config: {
+          name: "scout",
+          description: "Recon agent",
+          systemPrompt: "You are a scout.",
+          source: "user",
+          filePath: "/tmp/scout.md",
+        },
+        spawnedBy: "test",
+        cwd: tempDir,
+        modelRegistry: {} as any,
+        parentModel: undefined as any,
+        toolSyncEnabled: false,
+        onComplete: vi.fn(),
+      });
+
+      expect(mockSession.setActiveToolsByName).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

The `tools` field parsed from agent frontmatter was stored in `AgentConfig` but never consumed. Minions always got all tools regardless of what the agent definition specified.

Now calls `session.setActiveToolsByName(config.tools)` after extensions load, so agents with a tools allowlist only see those tools.

## Decisions & callouts

- **Placement** — filtering happens after `bindExtensions` and async tool sync, so extension-registered tools are also subject to the allowlist.
- **No tools field = all tools** — when `tools` is omitted from the agent frontmatter, behavior is unchanged (all tools available).

## Manual testing

- [x] Create an agent with `tools: read, bash` in frontmatter, spawn it, confirm it only has `read` and `bash` available (no `edit`, `write`, `quest`, etc.)