### PR TITLE
feat: support MINION.md subfolder agents

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -56,19 +56,23 @@ Stay focused. You have limited steps — get in, verify, report, get out.
 
 | Location | Scope | Walk-up? | Override priority |
 |----------|-------|----------|-------------------|
-| `~/.pi/agent/agents/` | Global | No | Lowest |
-| `~/.pi/agent/minions/` | Global | No | Low |
-| `~/.agents/agents/` | Global | No | Medium |
-| `.pi/agents/` | Project | Yes (to git root) | High |
-| `.agents/agents/` | Project | Yes (to git root) | Highest |
+| `~/.pi/agent/agents/` | Global | No | 1 (lowest) |
+| `~/.pi/agent/minions/` | Global | No | 2 |
+| `~/.agents/agents/` | Global | No | 3 |
+| `~/.agents/minions/` | Global | No | 4 |
+| `.pi/agents/` | Project | Yes (to git root) | 5 |
+| `.pi/minions/` | Project | Yes (to git root) | 6 |
+| `.agents/agents/` | Project | Yes (to git root) | 7 |
+| `.agents/minions/` | Project | Yes (to git root) | 8 (highest) |
 
 - **Global** agents are available in every project
 - **Project** agents live in the repo and are shared with collaborators
 - Project agents override global agents on name collision
 - "Walk-up" means pi-minions searches from the current directory up to the nearest `.git` root
+- Each discovery directory loads top-level `*.md` files and immediate child folders containing `MINION.md`
 
 > [!TIP]
-> Put team-shared agents in `.pi/agents/` (committed to the repo). Put personal agents in `~/.pi/agent/agents/` or `~/.agents/agents/`.
+> Put team-shared agents in `.pi/agents/` or `.pi/minions/` (committed to the repo). Put personal agents in `~/.pi/agent/agents/`, `~/.pi/agent/minions/`, `~/.agents/agents/`, or `~/.agents/minions/`.
 
 ## Discovering and using agents
 
@@ -79,7 +83,9 @@ The `list_agents` tool (or natural language like "what agents are available?") s
 ```bash
 # LLM calls list_agents automatically, or check manually:
 ls ~/.pi/agent/agents/
+ls ~/.pi/agent/minions/
 ls .pi/agents/
+ls .pi/minions/
 ```
 
 ### Spawn a named agent

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -220,10 +220,13 @@ Named agents are markdown files with YAML frontmatter discovered from multiple d
 | 1 (lowest) | `~/.pi/agent/agents/` | Global |
 | 2 | `~/.pi/agent/minions/` | Global |
 | 3 | `~/.agents/agents/` | Global |
-| 4 | `.pi/agents/` | Project (walks up to git root) |
-| 5 (highest) | `.agents/agents/` | Project (walks up to git root) |
+| 4 | `~/.agents/minions/` | Global |
+| 5 | `.pi/agents/` | Project (walks up to git root) |
+| 6 | `.pi/minions/` | Project (walks up to git root) |
+| 7 | `.agents/agents/` | Project (walks up to git root) |
+| 8 (highest) | `.agents/minions/` | Project (walks up to git root) |
 
-Project-local agents override global agents on name collision. See [Agents](agents.md) for the file format and frontmatter reference.
+Project-local agents override global agents on name collision. Each discovery directory loads top-level `*.md` files and immediate child folders containing `MINION.md`. See [Agents](agents.md) for the file format and frontmatter reference.
 
 ## Design decisions
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -13,6 +13,55 @@ const THINKING_LEVELS = new Set<ThinkingLevel>([
   "xhigh",
 ]);
 
+function loadAgentFromFile(
+  filePath: string,
+  source: AgentSource,
+  defaultName: string,
+): AgentConfig | null {
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+
+  const { frontmatter, body } = parseFrontmatter<Record<string, string>>(content);
+
+  if (!frontmatter.description) return null;
+
+  const name = frontmatter.name ?? defaultName;
+
+  const tools = frontmatter.tools
+    ?.split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
+
+  const thinking =
+    frontmatter.thinking && THINKING_LEVELS.has(frontmatter.thinking as ThinkingLevel)
+      ? (frontmatter.thinking as ThinkingLevel)
+      : undefined;
+
+  const steps =
+    frontmatter.steps || frontmatter.max_turns
+      ? parseInt(frontmatter.steps, 10) || parseInt(frontmatter.max_turns, 10) || undefined
+      : undefined;
+  const timeout = frontmatter.timeout ? parseInt(frontmatter.timeout, 10) || undefined : undefined;
+
+  return {
+    name,
+    displayName: frontmatter.displayName,
+    description: frontmatter.description,
+    tools: tools && tools.length > 0 ? tools : undefined,
+    model: frontmatter.model,
+    thinking,
+    steps,
+    timeout,
+    systemPrompt: body.trim(),
+    source,
+    filePath,
+  };
+}
+
 export function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
   if (!existsSync(dir)) return [];
 
@@ -23,60 +72,33 @@ export function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig
     return [];
   }
 
-  const agents: AgentConfig[] = [];
+  const agentMap = new Map<string, AgentConfig>();
 
   for (const entry of entries) {
     if (!entry.name.endsWith(".md")) continue;
     if (!entry.isFile() && !entry.isSymbolicLink()) continue;
 
-    const filePath = join(dir, entry.name);
-    let content: string;
+    const agent = loadAgentFromFile(join(dir, entry.name), source, entry.name.replace(/\.md$/, ""));
+    if (agent) agentMap.set(agent.name, agent);
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const filePath = join(dir, entry.name, "MINION.md");
+    let isFile = false;
     try {
-      content = readFileSync(filePath, "utf-8");
+      isFile = existsSync(filePath) && statSync(filePath).isFile();
     } catch {
       continue;
     }
+    if (!isFile) continue;
 
-    const { frontmatter, body } = parseFrontmatter<Record<string, string>>(content);
-
-    if (!frontmatter.description) continue;
-
-    const name = frontmatter.name ?? entry.name.replace(/\.md$/, "");
-
-    const tools = frontmatter.tools
-      ?.split(",")
-      .map((t) => t.trim())
-      .filter(Boolean);
-
-    const thinking =
-      frontmatter.thinking && THINKING_LEVELS.has(frontmatter.thinking as ThinkingLevel)
-        ? (frontmatter.thinking as ThinkingLevel)
-        : undefined;
-
-    const steps =
-      frontmatter.steps || frontmatter.max_turns
-        ? parseInt(frontmatter.steps, 10) || parseInt(frontmatter.max_turns, 10) || undefined
-        : undefined;
-    const timeout = frontmatter.timeout
-      ? parseInt(frontmatter.timeout, 10) || undefined
-      : undefined;
-
-    agents.push({
-      name,
-      displayName: frontmatter.displayName,
-      description: frontmatter.description,
-      tools: tools && tools.length > 0 ? tools : undefined,
-      model: frontmatter.model,
-      thinking,
-      steps,
-      timeout,
-      systemPrompt: body.trim(),
-      source,
-      filePath,
-    });
+    const agent = loadAgentFromFile(filePath, source, entry.name);
+    if (agent && !agentMap.has(agent.name)) agentMap.set(agent.name, agent);
   }
 
-  return agents;
+  return Array.from(agentMap.values());
 }
 
 function findProjectDir(cwd: string, ...subpath: string[]): string | null {
@@ -139,6 +161,6 @@ export function discoverAgents(
   for (const a of projectAgents) agentMap.set(a.name, a);
 
   const projectAgentsDir =
-    piProjectDir ?? dotAgentsProjectDir ?? piMinionsProjectDir ?? dotMinionsProjectDir;
+    piProjectDir ?? piMinionsProjectDir ?? dotAgentsProjectDir ?? dotMinionsProjectDir;
   return { agents: Array.from(agentMap.values()), projectAgentsDir };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export default function (pi: ExtensionAPI): void {
     description:
       "Delegate a task to a named agent or an ephemeral minion with isolated context. " +
       "If no agent name is provided, spawns an ephemeral minion with default capabilities. " +
-      "Agents are discovered from ~/.pi/agent/agents/ and .pi/agents/. " +
+      "Agents are discovered from global and project agent/minion directories, including ~/.pi/agent/{agents,minions}/, ~/.agents/{agents,minions}/, .pi/{agents,minions}/, and .agents/{agents,minions}/. " +
       "The agent runs as a file-based session with parent tracking.",
     promptSnippet: "Spawn a minion for isolated task delegation",
     promptGuidelines: [

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -112,6 +112,84 @@ describe("loadAgentsFromDir", () => {
     const scout = agents.find((a) => a.name === "scout");
     expect(scout?.systemPrompt.trim()).toBe("You are a scout.");
   });
+
+  it("loads MINION.md from immediate child directories", () => {
+    const tmpBase = join(tmpdir(), `pm-test-${Date.now()}`);
+    const agentsDir = join(tmpBase, "agents");
+    const reviewerDir = join(agentsDir, "reviewer");
+    mkdirSync(reviewerDir, { recursive: true });
+
+    writeFileSync(
+      join(reviewerDir, "MINION.md"),
+      "---\ndescription: Reviewer agent\n---\nYou are a reviewer.",
+    );
+
+    const agents = loadAgentsFromDir(agentsDir, "user");
+    const reviewer = agents.find((a) => a.name === "reviewer");
+    expect(reviewer).toBeDefined();
+    expect(reviewer?.description).toBe("Reviewer agent");
+    expect(reviewer?.filePath).toBe(join(reviewerDir, "MINION.md"));
+
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("uses frontmatter name from MINION.md when provided", () => {
+    const tmpBase = join(tmpdir(), `pm-test-${Date.now()}`);
+    const agentsDir = join(tmpBase, "agents");
+    const reviewerDir = join(agentsDir, "reviewer");
+    mkdirSync(reviewerDir, { recursive: true });
+
+    writeFileSync(
+      join(reviewerDir, "MINION.md"),
+      "---\nname: strict-reviewer\ndescription: Reviewer agent\n---\nYou are a reviewer.",
+    );
+
+    const agents = loadAgentsFromDir(agentsDir, "user");
+    expect(agents.find((a) => a.name === "reviewer")).toBeUndefined();
+    expect(agents.find((a) => a.name === "strict-reviewer")).toBeDefined();
+
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("prefers top-level markdown files over MINION.md on name collision", () => {
+    const tmpBase = join(tmpdir(), `pm-test-${Date.now()}`);
+    const agentsDir = join(tmpBase, "agents");
+    const reviewerDir = join(agentsDir, "reviewer");
+    mkdirSync(reviewerDir, { recursive: true });
+
+    writeFileSync(
+      join(agentsDir, "reviewer.md"),
+      "---\ndescription: Top-level reviewer\n---\nTop-level prompt.",
+    );
+    writeFileSync(
+      join(reviewerDir, "MINION.md"),
+      "---\ndescription: Nested reviewer\n---\nNested prompt.",
+    );
+
+    const agents = loadAgentsFromDir(agentsDir, "user");
+    const reviewer = agents.find((a) => a.name === "reviewer");
+    expect(reviewer?.description).toBe("Top-level reviewer");
+    expect(reviewer?.filePath).toBe(join(agentsDir, "reviewer.md"));
+
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("does not discover MINION.md deeper than one directory level", () => {
+    const tmpBase = join(tmpdir(), `pm-test-${Date.now()}`);
+    const agentsDir = join(tmpBase, "agents");
+    const nestedDir = join(agentsDir, "team", "reviewer");
+    mkdirSync(nestedDir, { recursive: true });
+
+    writeFileSync(
+      join(nestedDir, "MINION.md"),
+      "---\ndescription: Deep reviewer\n---\nDeep prompt.",
+    );
+
+    const agents = loadAgentsFromDir(agentsDir, "user");
+    expect(agents).toEqual([]);
+
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
 });
 
 describe("discoverAgents scope", () => {
@@ -142,6 +220,27 @@ describe("discoverAgents scope", () => {
     // The project version should win since it exists in .pi/agents under cwd
     expect(scout?.description).toBe("Project scout override");
     expect(scout?.source).toBe("project");
+
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("discovers agents from .pi/minions/ project directory via MINION.md", () => {
+    const tmpBase = join(tmpdir(), `pm-test-${Date.now()}`);
+    const minionDir = join(tmpBase, ".pi", "minions", "reviewer");
+    mkdirSync(minionDir, { recursive: true });
+
+    writeFileSync(
+      join(minionDir, "MINION.md"),
+      "---\ndescription: Project reviewer\n---\nProject reviewer prompt.",
+    );
+
+    mkdirSync(join(tmpBase, ".git"), { recursive: true });
+
+    const { agents } = discoverAgents(tmpBase, "project");
+    const reviewer = agents.find((a) => a.name === "reviewer");
+    expect(reviewer).toBeDefined();
+    expect(reviewer?.description).toBe("Project reviewer");
+    expect(reviewer?.source).toBe("project");
 
     rmSync(tmpBase, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary
- load immediate child directories containing `MINION.md` as agents
- keep top-level `*.md` precedence on name collision
- add tests for nested minion folders and `.pi/minions/` discovery
- update discovery docs and spawn tool description

## Example
- supports `.pi/minions/reviewer/MINION.md`
- name of the minion defaults to the dirname, if not present in `MINON.md` frontmatter `name` field.
- still ignores deeper nesting like `.pi/minions/team/reviewer/MINION.md`

## Verification
- npm run typecheck
- npm test