### PR TITLE
Fix minion subsession creation on Pi 0.68+

### DIFF
--- a/src/subsessions/manager.ts
+++ b/src/subsessions/manager.ts
@@ -5,6 +5,7 @@ import {
   createAgentSession,
   createCodingTools,
   DefaultResourceLoader,
+  getAgentDir,
   SessionManager,
   SettingsManager,
 } from "@mariozechner/pi-coding-agent";
@@ -79,8 +80,12 @@ export class SubsessionManager {
     this.writeMetadataFile(actualPath, metadata);
 
     // Set up resource loader with extensions filtered to prevent recursion
+    const agentDir = getAgentDir();
+    const settingsManager = SettingsManager.create(this.cwd, agentDir);
     const loader = new DefaultResourceLoader({
       cwd: this.cwd,
+      agentDir,
+      settingsManager,
       noExtensions: false,
       noSkills: false,
       noPromptTemplates: false,
@@ -104,7 +109,7 @@ export class SubsessionManager {
       tools: createCodingTools(this.cwd),
       customTools: options.customTools,
       sessionManager,
-      settingsManager: SettingsManager.create(),
+      settingsManager,
       modelRegistry,
       resourceLoader: loader,
     });

--- a/src/subsessions/manager.ts
+++ b/src/subsessions/manager.ts
@@ -3,7 +3,6 @@ import { join } from "node:path";
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
 import {
   createAgentSession,
-  createCodingTools,
   DefaultResourceLoader,
   getAgentDir,
   SessionManager,
@@ -106,7 +105,6 @@ export class SubsessionManager {
     const { session } = await createAgentSession({
       cwd: this.cwd,
       model: parentModel,
-      tools: createCodingTools(this.cwd),
       customTools: options.customTools,
       sessionManager,
       settingsManager,

--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -22,6 +22,7 @@ vi.mock("@mariozechner/pi-coding-agent", () => ({
     create: () => ({ getSessionFile: () => "/tmp/test-session.jsonl" }),
   },
   SettingsManager: { create: () => ({}) },
+  getAgentDir: () => "/tmp/pi-agent",
   createCodingTools: () => [],
 }));
 

--- a/test/subsessions/manager.test.ts
+++ b/test/subsessions/manager.test.ts
@@ -49,6 +49,7 @@ vi.mock("@mariozechner/pi-coding-agent", () => {
     SettingsManager: {
       create: vi.fn().mockReturnValue({}),
     },
+    getAgentDir: vi.fn().mockReturnValue("/tmp/pi-agent"),
     createCodingTools: vi.fn().mockReturnValue([]),
   };
 });


### PR DESCRIPTION
## Summary
- pass explicit cwd/agentDir settings into minion DefaultResourceLoader
- reuse the same SettingsManager for minion AgentSession creation
- let createAgentSession use Pi default tool selection instead of passing legacy Tool objects
- update SDK mocks for explicit agent dir lookup

## Testing
- npm test
- npm run typecheck *(fails locally: missing @mariozechner/pi-ai and @mariozechner/pi-agent-core type deps under pnpm strict node_modules)*

closes #12 