### PR TITLE
Remove README, CHANGELOG, and docs from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
   },
   "files": [
     "src/",
-    "docs/",
-    "README.md",
-    "CHANGELOG.md",
     "LICENSE.md"
   ],
   "peerDependencies": {


### PR DESCRIPTION
I was checking out pi-minions on the pi packages page and saw that the package size was 64 MB when most other extensions were <500 KB. Wanted to find out why before installing and saw that a lot of documentation and assets are included in the package, this change removes them to shrink the size down to ~200 KB.

See

https://stackoverflow.com/a/53635574
https://blog.npmjs.org/post/165769683050/publishing-what-you-mean-to-publish